### PR TITLE
More updates.

### DIFF
--- a/src/db/expertise_missing_by_bocouper.sql
+++ b/src/db/expertise_missing_by_bocouper.sql
@@ -14,4 +14,4 @@ AND (
   WHERE ee.employee_id=e.id AND ee.expertise_id=exp.id
 ) = 0
 AND exp.description IS NOT null
-ORDER BY exp.name
+ORDER BY ea.name, exp.name

--- a/src/robocoup/commands/expertise.js
+++ b/src/robocoup/commands/expertise.js
@@ -288,7 +288,7 @@ function updateExpertise({user, expertise, newValues}) {
       }
       return `${name} changed from ${oldValues[prop]} to ${newValues[prop]}.`;
     }).join(' ');
-    return `Expertise for *${expertise.expertise}* updated: ${summary}`;
+    return `_Expertise for *${expertise.expertise}* updated: ${summary}_`;
   });
 }
 
@@ -433,10 +433,11 @@ addCommand('update', {
     const user = getName(parsed.options.user) || this.user.name;
     const search = parsed.remain.join(' ');
     const output = [...parsed.errors];
+    const {postMessage} = this;
 
     if (search === 'missing') {
       return updateMissing({
-        postMessage: this.postMessage,
+        postMessage,
         user,
       });
     }
@@ -465,7 +466,7 @@ addCommand('update', {
       }
       const command = `expertise update ${search.toLowerCase()}`;
       return updateExpertiseDialog({
-        postMessage: this.postMessage,
+        postMessage,
         user,
         expertise: match,
         command,

--- a/src/robocoup/commands/expertise.js
+++ b/src/robocoup/commands/expertise.js
@@ -298,6 +298,7 @@ function updateExpertiseDialog({
   expertise,
   command,
   oneTimeHeader = null,
+  skippable = false,
   done,
 }) {
   const expertiseName = `*${expertise.expertise}*`;
@@ -355,7 +356,10 @@ function updateExpertiseDialog({
             if (match === 2) {
               return getQuestions('_Starting over._');
             }
-            return updateExpertise({user, expertise, newValues}).then(done);
+            return updateExpertise({user, expertise, newValues}).then(done)
+            // Ensure that the very last "message" is treated as a message and
+            // not as an array of questions.
+            .then(d => d instanceof Dialog ? d : {message: d});
           },
         },
       ];
@@ -371,7 +375,15 @@ function updateExpertiseDialog({
       postMessage,
       timeout: 60,
       onTimeout: `Timed out, please type \`${command}\` to try again.`,
-      onCancel: () => {
+      prompt: ({timeout, exit: [exit, skip]}) => {
+        const exitSkip = skippable ? `Type *${skip}* to skip, or *${exit}* to cancel.` : `Type *${exit}* to cancel.`;
+        return `_You have ${timeout} seconds to answer. ${exitSkip}_`;
+      },
+      exit: skippable ? ['exit', 'skip'] : ['exit'],
+      onExit: match => {
+        if (match === 'skip') {
+          return done(`_Skipping ${expertiseName} for now!_`, true);
+        }
         return `Canceled, please type \`${command}\` to try again.`;
       },
     });
@@ -387,26 +399,30 @@ function updateExpertiseDialog({
 }
 
 function updateMissing({postMessage, user}) {
-  let n = 0;
+  let i = 0;
+  const skipped = [];
+  const expertiseCount = n => `${n.length} expertise${n.length === 1 ? '' : 's'}`;
   function ask(header) {
-    n++;
+    i++;
     return query('expertise_missing_by_bocouper', user)
     .then(missing => {
-      if (missing.length === 0) {
-        return heredoc.trim.unindent`
-          You have no outstanding expertise data.
-          View your expertise list with \`expertise me\`.
-        `;
+      const notSkipped = missing.filter(({id}) => skipped.indexOf(id) === -1);
+      if (notSkipped.length === 0) {
+        const done = i > 1 ? 'Done. ' : '';
+        return [
+          header,
+          missing.length === 0 ? `${done}You have no outstanding expertise data.` :
+            `${done}You still have outstanding expertise data for ${expertiseCount(missing)}.`,
+          'View your expertise list with `expertise me`.',
+        ];
       }
-      const expertise = missing[0];
-      const identifier = missing.length === 1 ? 'it' : n === 1 ? 'the first' : 'the next';
-      const now = n > 1 ? ' now' : '';
+      const expertise = notSkipped[0];
+      const identifier = notSkipped.length === 1 ? 'it' : i === 1 ? 'the first' : 'the next';
+      const now = i > 1 ? ' now' : '';
+      const skipTxt = skipped.length > 0 ? ` (you've skipped ${skipped.length})` : '';
       const oneTimeHeader = [
         ...(header ? [header, ''] : []),
-        heredoc.trim.oneline`
-          You${now} have no data for ${missing.length} expertise${missing.length === 1 ? '' : 's'}.
-          Let's update ${identifier}:
-        `,
+        `I${now} need data for ${expertiseCount(notSkipped)}${skipTxt}. Let's update ${identifier}:`,
       ];
       return updateExpertiseDialog({
         postMessage,
@@ -414,7 +430,13 @@ function updateMissing({postMessage, user}) {
         expertise,
         command: 'expertise update missing',
         oneTimeHeader,
-        done: ask,
+        skippable: true,
+        done: (result, skip) => {
+          if (skip) {
+            skipped.push(expertise.id);
+          }
+          return ask(result);
+        },
       });
     });
   }
@@ -471,7 +493,7 @@ addCommand('update', {
         expertise: match,
         command,
         oneTimeHeader: output.splice(0, output.length),
-        done: m => ({message: done(m)}),
+        done,
       });
     })
     // Error! Print all cached output + error message + usage info, or re-throw.

--- a/src/robocoup/index.js
+++ b/src/robocoup/index.js
@@ -40,14 +40,32 @@ function getPostMessage({channel, botname}) {
     if (Array.isArray(text)) {
       text = normalizeResult(text);
     }
-    if (text) {
+    if (!text) {
+      return Promise.resolve();
+    }
+    // Return a promise that resolves when channel.postMessage gets a response.
+    // I have no idea why it doesn't just do this!
+    return new Promise((resolve, reject) => {
+      // Override the built-in method that gets called on postMessage response.
+      channel._onPostMessage = data => {
+        // Remove the override, and call the original method.
+        delete channel._onPostMessage;
+        channel._onPostMessage(data);
+        // Resolve or reject as-appropriate.
+        if (data.ok) {
+          resolve(data);
+        }
+        else {
+          reject(data);
+        }
+      };
       channel.postMessage({
         username: botname,
         text,
         unfurl_links: false,
         unfurl_media: false,
       });
-    }
+    });
   };
 }
 

--- a/src/robocoup/index.js
+++ b/src/robocoup/index.js
@@ -27,10 +27,11 @@ function log(command) {
 }
 
 function getPostMessage({channel, botname}) {
-  // Flatten result array and remove `null` items, then join on newline.
+  // Flatten result array and remove null, undefined or false items, then
+  // join on newline.
   const normalizeResult = R.pipe(
     R.flatten,
-    R.reject(R.isNil),
+    R.reject(s => R.isNil(s) || s === false),
     R.join('\n')
   );
   // Return a function that normalizes result (if necessary) and posts


### PR DESCRIPTION
* Sort missing expertises by area then name. Closes #70.
* Allow skipping in "Expertise update missing". Closes #74.

Also:

* Promotde some helper functions to methods.
* Return a promise when calling postMessage to allow chaining.
* Filter out `false` array values when normalizing messages.

Dialog-specific changes:

* `exit` and `onExit` may now be specified when creating a dialog instance, `exit` and `onExit` specified at the question-level will override
* `exit` may be an array, in which case any matching item will call the `onExit` handler and exit the dialog
* `onExit` now receives the exit word used as its first argument
* artificial delay when using `say()` is now removed in favor of the promise that `postMessage` returns
