### PR TITLE
Adding formatting to expertise status output

### DIFF
--- a/src/robocoup/commands/expertise.js
+++ b/src/robocoup/commands/expertise.js
@@ -80,12 +80,17 @@ function abort(...args) {
 // Get user name sans leading sigil.
 const getName = (name = '') => name.replace(/^@/, '');
 
+// Formating helper - formats a value into a small bar graph like this: ●●●○○ (3)
+function formatStatusBar(value) {
+  return `${'\u25CF'.repeat(value)}${'\u25CB'.repeat(5 - value)}`;
+}
+
 // Data-formatting helper.
 function formatByInterestAndExperience(rows, fn) {
-  return rows.map(row => {
+  return [`> *Interest*     |  *Experience*`].concat(rows.map(row => {
     const [interest, experience] = row.interest_experience;
-    return `> *Interest=${interest}, Experience=${experience}:* ${fn(row)}`;
-  });
+    return `> ${formatStatusBar(interest)} (${interest}) | ${formatStatusBar(experience)} (${experience}): ${fn(row)}`;
+  }));
 }
 
 // Find matching expertises for the given search term.


### PR DESCRIPTION
Referencing issue #97.

Output now looks like this, with tiny graphs to indicate Interest/Experience.

![image](https://cloud.githubusercontent.com/assets/18690/13648790/87266a26-e608-11e5-9aa3-65fc8575fe4a.png)
