### PR TITLE
Update bots to use chatter 0.3. Closes #131.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
         src: [
           'src/index.js',
           'src/lib/args.js',
+          'src/lib/bot-helpers.js',
           'src/lib/bot.js',
           'src/lib/bot/**/*.js',
           'src/lib/slack.js',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
         spawn: false,
       },
       config: {
-        files: ['config.js'],
+        files: ['.env', 'config.js'],
         tasks: ['kill', 'start'],
       },
       src: {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "babel-register": "^6.4.3",
     "babel-runtime": "^6.3.19",
     "bluebird": "^3.1.1",
-    "chatter": "~0.2.3",
+    "chatter": "~0.3.0",
     "cron": "^1.1.0",
     "dotenv": "^2.0.0",
     "heredoc-tag": "^0.1.0",

--- a/src/lib/bot-helpers.js
+++ b/src/lib/bot-helpers.js
@@ -1,0 +1,32 @@
+// =====================
+// Misc SlackBot helpers
+// =====================
+
+const bot = {};
+
+export default function mixinBotHelpers(target) {
+  for (const prop in bot) {
+    target[prop] = bot[prop];
+  }
+}
+
+// Get user name sans leading sigil, eg: cowboy
+bot.getName = function(name) {
+  return this.parseMessage(name || '').replace(/^@/, '');
+};
+
+// Get user object.
+bot.getUser = function(name) {
+  return this.slack.rtmClient.dataStore.getUserByName(this.getName(name));
+};
+
+// Get real name and fallback to user name.
+bot.getRealName = function(name) {
+  const user = this.getUser(name);
+  return user.real_name || user.name;
+};
+
+// Get formatted slackname, eg: <@U025GMQTB>
+bot.formatUser = function(name) {
+  return `<@${this.getUser(name).id}>`;
+};

--- a/src/new-bot/commands/expertise.js
+++ b/src/new-bot/commands/expertise.js
@@ -175,7 +175,7 @@ const forCommand = createCommand({
   name: 'for',
   description: 'List all expertises for the given Bocouper, grouped by interest and experience.',
   usage: '[me | @bocouper]',
-}, createParser((args, meta) => forHandler(args.remain[0], meta)));
+}, createParser(({args: [name]}, meta) => forHandler(name, meta)));
 
 const meCommand = createCommand({
   name: 'me',
@@ -197,8 +197,8 @@ const findCommand = createCommand({
   name: 'find',
   description: 'List all Bocoupers with the given expertise, grouped by interest and experience.',
   usage: '<expertise name>',
-}, createParser(({remain}) => {
-  const search = remain.join(' ');
+}, createParser(({args}) => {
+  const search = args.join(' ');
   if (!search) {
     return false;
   }
@@ -232,8 +232,8 @@ const statsCommand = createCommand({
   name: 'stats',
   description: 'Provide statistics about a given expertise.',
   usage: '<expertise name>',
-}, createParser(({remain}) => {
-  const search = remain.join(' ');
+}, createParser(({args}) => {
+  const search = args.join(' ');
   if (!search) {
     return false;
   }
@@ -329,8 +329,8 @@ const updateCommand = createCommand({
       experience: Number,
       interest: Number,
     },
-  }, ({remain, options: newValues, errors}, {user}) => {
-    const search = remain.join(' ');
+  }, ({args, options: newValues, errors}, {user}) => {
+    const search = args.join(' ');
     if (!search) {
       return false;
     }
@@ -365,9 +365,7 @@ const updateCommand = createCommand({
   }),
 ]);
 
-/* eslint no-use-before-define: 0 */
-
-const expertiseCommand = createCommand({
+export default createCommand({
   name: 'expertise',
   description: 'Show your expertise.',
 }, [
@@ -379,5 +377,3 @@ const expertiseCommand = createCommand({
   scalesCommand,
   updateCommand,
 ]);
-
-export default expertiseCommand;

--- a/src/new-bot/commands/perch.js
+++ b/src/new-bot/commands/perch.js
@@ -32,7 +32,7 @@ function getMetricText(who) {
 
 export default createCommand({
   name: 'perch',
-  description: 'Show information about perch',
+  description: 'Show information about perch.',
 }, (str, {user}) => {
   return Promise.all([
     getPerching(),

--- a/src/new-bot/commands/pipeline.js
+++ b/src/new-bot/commands/pipeline.js
@@ -30,7 +30,7 @@ const stages = [
 
 export default createCommand({
   name: 'pipeline',
-  description: 'Show information about our sales pipeline',
+  description: 'Show information about our sales pipeline.',
 }, () => {
   return query('sales_pipeline').then(metrics => {
     const year = moment().format('YYYY');

--- a/src/new-bot/commands/status.js
+++ b/src/new-bot/commands/status.js
@@ -7,9 +7,9 @@ import {query} from '../../lib/db';
 
 export default createCommand({
   name: 'status',
-  description: 'Show the status of a Bocouper today',
+  description: 'Show the status of a Bocouper today.',
   usage: '[me | @bocouper]',
-}, createParser(({remain: [slackname]}, {bot, user}) => {
+}, createParser(({args: [slackname]}, {bot, user}) => {
   if (!slackname) {
     return false;
   }

--- a/src/new-bot/commands/status.js
+++ b/src/new-bot/commands/status.js
@@ -17,7 +17,7 @@ export default createCommand({
     slackname = user.name;
   }
   else {
-    slackname = bot.parseMessage(slackname).replace(/^@/, '');
+    slackname = bot.getName(slackname);
   }
   return query('status', slackname).get(0).then(status => {
     if (!status) {

--- a/src/new-bot/index.js
+++ b/src/new-bot/index.js
@@ -12,6 +12,7 @@ import versionCommand from './commands/version';
 
 const bot = createSlackBot({
   name: 'Robocoup Mk. II',
+  icon: 'https://dl.dropboxusercontent.com/u/294332/Bocoup/bots/robocoup_icon.png',
   getSlack() {
     return {
       rtmClient: new RtmClient(config.tokens.newbot, {
@@ -24,6 +25,8 @@ const bot = createSlackBot({
   createMessageHandler(id, {channel}) {
     // Direct message
     if (channel.is_im) {
+      // Wrapping the command in a conversation allows the bot to be aware of
+      // when a command returns a "dialog".
       return createConversation([
         // Nameless command that encapsulates sub-commands and adds a "help"
         // command and a fallback message handler.

--- a/src/new-bot/index.js
+++ b/src/new-bot/index.js
@@ -1,5 +1,6 @@
 import {RtmClient, WebClient, MemoryDataStore} from '@slack/client';
 import {createSlackBot, createConversation, createCommand} from 'chatter';
+import mixinBotHelpers from '../lib/bot-helpers';
 import config from '../../config';
 
 import expertiseCommand from './commands/expertise';
@@ -46,5 +47,8 @@ const bot = createSlackBot({
     }
   },
 });
+
+// Mixin bot helpers.
+mixinBotHelpers(bot);
 
 export default bot;

--- a/src/pombot/commands/iwill.js
+++ b/src/pombot/commands/iwill.js
@@ -1,24 +1,25 @@
 /*
  * A stub for the "i will" command.
  */
-
+import heredoc from 'heredoc-tag';
 import {createCommand} from 'chatter';
 import {states} from '../pomConfig';
 
-export default function(pom) {
-  return createCommand({
-    name: 'i will',
-    description: 'Records a users task for the next pom.',
-  }, (message, {user, channel}) => {
-    switch (pom.state) {
-      case states.RUNNING:
-        return `it's too late to declare a task, a pom is running with *${pom.getTimeString(pom.timeLeft)}* left.`;
-        break;
-      default:
-        // if pom is not running or is on break, let user record task
-        pom.taskCollection[user.name] = message;
-        return `${user.name}'s task for the next pom is "${message}". you can start this pom with the command \`start\``;
-        break;
-    }
-  });
-}
+export default createCommand({
+  name: 'i will',
+  description: 'Records a users task for the next pom.',
+}, (message, {user, channel, pom, getCommand}) => {
+  switch (pom.state) {
+    case states.RUNNING:
+      return `it's too late to declare a task, a pom is running with *${pom.getTimeString(pom.timeLeft)}* left.`;
+      break;
+    default:
+      // if pom is not running or is on break, let user record task
+      pom.taskCollection[user.name] = message;
+      return heredoc.oneline.trim`
+        ${user.name}'s task for the next pom is "${message}".
+        You can start this pom with the command \`${getCommand('start')}\`
+      `;
+      break;
+  }
+});

--- a/src/pombot/commands/start.js
+++ b/src/pombot/commands/start.js
@@ -4,24 +4,22 @@
 import {createCommand} from 'chatter';
 import {states} from '../pomConfig';
 
-export default function(pom) {
-  return createCommand({
-    name: 'start',
-    description: 'Starts a pom timer.',
-  }, message => {
+export default createCommand({
+  name: 'start',
+  description: 'Starts a pom timer.',
+}, (message, {pom}) => {
 
-    switch (pom.state) {
-      case states.RUNNING:
-        return `there is already a pom running with *${pom.getTimeString(pom.timeLeft)}* left.`;
-        break;
-      case states.ON_BREAK:
-        return `we are in the middle of a break with *${pom.getTimeString(pom.timeLeft)}* left.`;
-        break;
-      default:
-        // if pom is not running, start a new one
-        pom.start();
-        return `:tomato: pom started – you have *${pom.getTimeString(pom.maxSeconds)}* left!`;
-        break;
-    }
-  });
-}
+  switch (pom.state) {
+    case states.RUNNING:
+      return `there is already a pom running with *${pom.getTimeString(pom.timeLeft)}* left.`;
+      break;
+    case states.ON_BREAK:
+      return `we are in the middle of a break with *${pom.getTimeString(pom.timeLeft)}* left.`;
+      break;
+    default:
+      // if pom is not running, start a new one
+      pom.start();
+      return `:tomato: pom started – you have *${pom.getTimeString(pom.maxSeconds)}* left!`;
+      break;
+  }
+});

--- a/src/pombot/commands/status.js
+++ b/src/pombot/commands/status.js
@@ -1,34 +1,39 @@
 /*
  * The `status` command, which describes the status of a current Pom.
  */
+import heredoc from 'heredoc-tag';
 import {createCommand} from 'chatter';
 import {states} from '../pomConfig';
 
-export default function(pom) {
-  return createCommand({
-    name: 'status',
-    description: 'Displays the status of the current pom.',
-  }, (message, {channel}) => {
+export default createCommand({
+  name: 'status',
+  description: 'Displays the status of the current pom.',
+}, (message, {channel, pom, getCommand}) => {
 
-    // retrieve any tasks in this pom.
-    const taskList = [];
-    for (const user in pom.taskCollection) {
-      taskList.push(`> ${user} will ${pom.taskCollection[user]}`);
-    }
+  // retrieve any tasks in this pom.
+  const taskList = [];
+  for (const user in pom.taskCollection) {
+    taskList.push(`> ${user} will ${pom.taskCollection[user]}`);
+  }
 
-    const taskHeader = (taskList.length > 0) ? 'here is the task list:' : 'there are no tasks declared.';
+  const taskHeader = (taskList.length > 0) ? 'here is the task list:' : 'there are no tasks declared.';
 
-    switch (pom.state) {
-      case states.RUNNING:
-      case states.ON_BREAK:
-        // if pom is running, get time left
-        const timeLeft = pom.getTimeString(pom.timeLeft);
-        return [`a pom is currently running with *${timeLeft}* left and ${taskHeader}`, taskList];
-        break;
-      default:
-        // if pom is not running
-        return [`there is no pom currently running – start one with the command \`start\`. ${taskHeader}`, taskList];
-        break;
-    }
-  });
-}
+  switch (pom.state) {
+    case states.RUNNING:
+    case states.ON_BREAK:
+      // if pom is running, get time left
+      const timeLeft = pom.getTimeString(pom.timeLeft);
+      return [`a pom is currently running with *${timeLeft}* left and ${taskHeader}`, taskList];
+      break;
+    default:
+      // if pom is not running
+      return [
+        heredoc.oneline.trim`
+          there is no pom currently running – start one with the command \`${getCommand('start')}\`.
+          ${taskHeader}
+        `,
+        taskList,
+      ];
+      break;
+  }
+});

--- a/src/pombot/commands/stop.js
+++ b/src/pombot/commands/stop.js
@@ -4,23 +4,21 @@
 import {createCommand} from 'chatter';
 import {states} from '../pomConfig';
 
-export default function(pom) {
-  return createCommand({
-    name: 'stop',
-    description: 'Stops the current pom.',
-  }, (message, {channel}) => {
-    switch (pom.state) {
-      case states.RUNNING:
-      case states.ON_BREAK:
-        // if pom is running, get time left stop it
-        const timeLeft = pom.getTimeString(pom.timeLeft);
-        pom.stop();
-        return `:tomato: the pom has been stopped with *${timeLeft}* remaining.`;
-        break;
-      default:
-        // if pom is not running
-        return `there is no pom currently running – start one with the command \`start\``;
-        break;
-    }
-  });
-}
+export default createCommand({
+  name: 'stop',
+  description: 'Stops the current pom.',
+}, (message, {channel, pom, getCommand}) => {
+  switch (pom.state) {
+    case states.RUNNING:
+    case states.ON_BREAK:
+      // if pom is running, get time left stop it
+      const timeLeft = pom.getTimeString(pom.timeLeft);
+      pom.stop();
+      return `:tomato: the pom has been stopped with *${timeLeft}* remaining.`;
+      break;
+    default:
+      // if pom is not running
+      return `there is no pom currently running – start one with the command \`${getCommand('start')}\``;
+      break;
+  }
+});

--- a/src/thanksbot/index.js
+++ b/src/thanksbot/index.js
@@ -14,6 +14,7 @@ const messageHandler = (message, {user, bot, slack}) => {
 
 const bot = createSlackBot({
   name: 'Thanksbot',
+  icon: 'https://avatars.slack-edge.com/2016-01-07/17962262403_c150282ec5ef067ea5cc_512.png',
   verbose: true,
   getSlack() {
     return {


### PR DESCRIPTION
* Update chatter to ~0.3.0 in package.json.
* Restart bot when .env file changes.
* Move bot helper methods into reusable lib/bot-helpers module.
* Update newbot to use chatter 0.3.
  * Add Robocoup icon.
  * Minor cleanup.
* Update thanksbot
  * Add thanksbot icon.
* Update pombot to use chatter 0.3.
  * Add tomato icon.
  * Enable logging of stack traces on exceptions.
  * Add "getCommand" command name formatting helper function.
  * Convert sub-command factories into commands.
  * Use createArgsAdjuster to pass pom instance and name formatting helper
    function into commands instead of using factories and closures.
  * Reduce repetition in SlackBot createMessageHandler code.
  * Use heredoc-tag lib to format a few lines that would have been > 120 chars.
