### PR TITLE
Minor deployment-related tweaks + documentation.

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -107,7 +107,7 @@ secret_vars:
     dest: RDS
   - src: rds-bocoup-db/db/bocoup
     dest: BOT_DB
-  - src: bot-keys
+  - src: bots/bots-production
     dest: BOT_KEYS
   - src: ses
     dest: SES

--- a/deploy/ansible/roles/deploy/tasks/checkout.yml
+++ b/deploy/ansible/roles/deploy/tasks/checkout.yml
@@ -7,9 +7,9 @@
 
 - name: clone git repo into temp directory
   git:
-    repo={{base_path ~ "/vagrant" if local else git_repo}}
-    dest={{clone_path}}
-    version={{commit}}
+    repo: "{{base_path ~ '/vagrant' if local else git_repo}}"
+    dest: "{{clone_path}}"
+    version: "{{commit}}"
 
 - name: get sha of cloned repo
   command: git rev-parse HEAD

--- a/deploy/ansible/roles/services/tasks/main.yml
+++ b/deploy/ansible/roles/services/tasks/main.yml
@@ -1,2 +1,15 @@
-- name: bot daemon is loaded
-  template: src=bots.conf dest=/etc/init/ backup=no
+- name: ensure upstart script for bots app is in place
+  template:
+    src: bots.conf
+    dest: /etc/init
+
+- name: check if deployment dir exists
+  stat:
+    path: "{{site_path}}"
+  register: site_path_check
+
+- name: start app
+  service:
+    name: bots
+    state: restarted
+  when: site_path_check.stat.exists

--- a/deploy/ansible/roles/services/templates/bots.conf
+++ b/deploy/ansible/roles/services/templates/bots.conf
@@ -21,6 +21,8 @@ env {{key}}
 env RUN_JOBS=true
 {% endif %}
 
+chdir {{site_path}}
+
 script
-  /usr/bin/npm start --prefix {{site_path}}
+  /usr/bin/npm start
 end script

--- a/deploy/ansible/roles/services/templates/bots.conf
+++ b/deploy/ansible/roles/services/templates/bots.conf
@@ -4,8 +4,6 @@ start on startup
 stop on shutdown
 respawn
 
-env NODE_ENV={{env}}
-{% if env == "production" %}
 {% for key in RDS.splitlines() %}
 env {{key}}
 {% endfor %}
@@ -18,8 +16,8 @@ env {{key}}
 {% for key in SES.splitlines() %}
 env {{key}}
 {% endfor %}
-env RUN_JOBS=true
-{% endif %}
+
+env NODE_ENV={{env}}
 
 chdir {{site_path}}
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "wordwrap": "^1.0.0"
   },
   "scripts": {
-    "get-secrets": "ssh nest.bocoup.com cat /mnt/secrets/{ses,rds-bocoup-db/{connection,db/bocoup-staging}} > .env",
+    "get-secrets": "ssh nest.bocoup.com cat /mnt/secrets/{ses,bots/bots-dev,rds-bocoup-db/{connection,db/bocoup-staging}} > .env",
     "db": "export $(<.env) && psql $PGNAME",
     "start": "babel-node ./src/index",
     "start-dev": "grunt",


### PR DESCRIPTION
* I created bots-specific secrets files in `/mnt/secrets/bots/`
* I moved the `RUN_JOBS` env var into those secrets files (it's enabled in production, disabled in dev)
* I added this wiki page a la skillsbot and pombot: https://github.com/bocoup/bots/wiki/Deployment

I didn't take the time to re-write the instructions for creating new bots or developing existing ones.

@tkellen if this works for you, feel free to merge.