### PR TITLE
Update Node version in ansible scripts

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -30,10 +30,10 @@ apt_keys:
 # Ppas to be added to apt. Useful ppas (replace trusty with your Ubuntu
 # version codename, if necessary):
 # Git latest:     ppa:git-core/ppa
-# Node.js 4.2.x (LTS): deb https://deb.nodesource.com/node_4.x trusty main
-# Node.js 5.x.x: deb https://deb.nodesource.com/node_5.x trusty main
+# Node.js 10.0.x (LTS): deb https://deb.nodesource.com/node_10.x trusty main
+# Node.js 12.x.x: deb https://deb.nodesource.com/node_12.x trusty main
 apt_ppas:
-  - "deb https://deb.nodesource.com/node_4.x trusty main"
+  - "deb https://deb.nodesource.com/node_10.x trusty main"
   - "ppa:git-core/ppa"
 
 # Any apt packages to install. Apt package versions may be specified like


### PR DESCRIPTION
The npm dependencies had an update recently (af1b123) so I decided to stick with just this node update here.

Also I noticed some things:

We have grunt set to run eslint, mocha, and set a development "watch" mode. Although, mocha is not used, no tests yet. Eslint is misused, at least it finds errors but they are not new within this PR.

I suggest we plan a follow up work to remove Grunt usage, update lint/style checker usage using npm package scripts and set a few unit tests that could be helpful or get rid of mocha while we don't have anything set.

